### PR TITLE
add `newrelic_infra` prefix to all variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ All typical interactions with `infra-agent-ansible` will be done through role co
 ---
 hosts: ap_ne_1
 roles:
-  - { role: infra-agent-ansible, license_key: YOUR_LICENSE_KEY }
+  - { role: infra-agent-ansible, newrelic_infra_license_key: YOUR_LICENSE_KEY }
 ```
 
 ## Reference
@@ -47,7 +47,7 @@ roles:
 
 #### Variables
 
-##### `agent_state` (OPTIONAL)
+##### `newrelic_infra_agent_state` (OPTIONAL)
 
 Describes what you want to do with the agent:
 
@@ -62,22 +62,22 @@ What version of the agent do you want to install:
 * `'*'`       - [default] install the latest version of the agent.
 * `'X.Y.ZZZ'` - string of the specific version number you want to install, e.g.  1.0.280
 
-##### `os_name` (OPTIONAL)
+##### `newrelic_infra_os_name` (OPTIONAL)
 
 Specifies the target OS that the Infrastructure agent will be installed on.
 Defaults to `ansible_os_family`. See list in the `meta/main.yml` file for latest list that is supported.
 
-##### `os_version` (OPTIONAL)
+##### `newrelic_infra_os_version` (OPTIONAL)
 
 Specifies the OS version of the installer package needed for this machine.
 Defaults to `ansible_lsb.major_release`. Mostly used for `RedHat` family OSs. See list in the `meta/main.yml` file for latest list.
 
-##### `os_codename` (OPTIONAL)
+##### `newrelic_infra_os_codename` (OPTIONAL)
 
 Specifies the OS codename of the installer package needed for this machine.
 Defaults to `ansible_lsb.codename`. Mostly used for `Debian` family OSs. See list in the `meta/main.yml` file for latest list.
 
-##### `license_key` (REQUIRED)
+##### `newrelic_infra_license_key` (REQUIRED)
 
 Specifies the New Relic license key to use.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,23 +4,23 @@
 # Repository configs, must be one of the values in meta/main.yml
 #
 
-os_name: "{{ ansible_os_family }}"
-os_version: "{{ ansible_lsb.major_release }}"
-os_codename: "{{ ansible_lsb.codename }}"
+newrelic_infra_os_name: "{{ ansible_os_family }}"
+newrelic_infra_os_version: "{{ ansible_lsb.major_release }}"
+newrelic_infra_os_codename: "{{ ansible_lsb.codename }}"
 
 #
 # New Relic Infrastructure agent configs
 #
 
 # New Relic license key
-license_key: ""
+newrelic_infra_license_key: ""
 
 # Agent package state
 # Values:
 #   "present" or "latest" will install
 #   "absent" will uninstall
-agent_state: "latest"
+newrelic_infra_agent_state: "latest"
 
 # (Optional) Specific Infrastructure agent version to install
-# To install latest use: agent_state="latest" agent_version="*"
-agent_version: "*"
+# To install latest use: newrelic_infra_agent_state="latest" newrelic_infra_agent_version="*"
+newrelic_infra_agent_version: "*"

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -5,59 +5,59 @@
 #
 - name: Confirm RedHat lsb util is present
   yum: name=redhat-lsb-core state=present
-  when: os_name|lower == 'redhat'
+  when: newrelic_infra_os_name|lower == 'redhat'
 
 - name: Reread ansible_lsb facts
   setup: filter=ansible_lsb*
-  when: os_name|lower == 'redhat'
+  when: newrelic_infra_os_name|lower == 'redhat'
 
 - name: setup agent repo keys
   apt_key:
     url: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     state: present
-  when: os_name|lower == 'debian'
+  when: newrelic_infra_os_name|lower == 'debian'
 
 - name: setup agent repo keys
   rpm_key:
     key: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     state: present
-  when: os_name|lower == 'redhat'
+  when: newrelic_infra_os_name|lower == 'redhat'
 
 - name: setup agent repo reference
   apt_repository:
-    repo: "deb https://download.newrelic.com/infrastructure_agent/linux/apt {{ os_codename }} main"
+    repo: "deb https://download.newrelic.com/infrastructure_agent/linux/apt {{ newrelic_infra_os_codename }} main"
     state: present
-  when: os_name|lower == 'debian'
+  when: newrelic_infra_os_name|lower == 'debian'
 
 - name: setup agent repo reference
   yum_repository:
-    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ os_version }}/x86_64"
+    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ newrelic_infra_os_version }}/x86_64"
     gpgcheck: yes
     gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     name: 'New-Relic-Infrastructure'
     repo_gpgcheck: yes
     state: present
     description: New Relic Infrastructure
-  when: os_name|lower == 'redhat'
+  when: newrelic_infra_os_name|lower == 'redhat'
 
 - name: install agent
   yum:
-    name: "newrelic-infra{{ agent_version }}"
-    state: "{{ agent_state }}"
-  when: os_name|lower == 'redhat'
+    name: "newrelic-infra{{ newrelic_infra_agent_version }}"
+    state: "{{ newrelic_infra_agent_state }}"
+  when: newrelic_infra_os_name|lower == 'redhat'
 
 - name: install agent
   apt:
-    name: "newrelic-infra{{ agent_version }}"
-    state: "{{ agent_state }}"
+    name: "newrelic-infra{{ newrelic_infra_agent_version }}"
+    state: "{{ newrelic_infra_agent_state }}"
     update_cache: yes
-  when: os_name|lower == 'debian'
+  when: newrelic_infra_os_name|lower == 'debian'
 
 - name: setup agent config
   template: src=newrelic-infra.yml.j2 dest=/etc/newrelic-infra.yml
   notify: restart newrelic-infra
-  when: agent_state != "absent"
+  when: newrelic_infra_agent_state != "absent"
 
 - name: setup agent service
   service: name=newrelic-infra state=started enabled=yes
-  when: agent_state != "absent"
+  when: newrelic_infra_agent_state != "absent"

--- a/templates/newrelic-infra.yml.j2
+++ b/templates/newrelic-infra.yml.j2
@@ -1,1 +1,1 @@
-license_key: {{ license_key }}
+license_key: {{ newrelic_infra_license_key }}

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -3,4 +3,4 @@
   remote_user: root
   roles:
     - role: infra-agent-ansible
-      license_key: YOUR_NR_LICENSE_KEY
+      newrelic_infra_license_key: YOUR_NR_LICENSE_KEY


### PR DESCRIPTION
Having a prefix for variables in a role is important so that they don't collide with other roles.