### PR TITLE
ensure apt-transport-https is installed on Debian based OS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,7 @@ Pull requests should:
 By contributing to this project you agree that you are granting New Relic a non-exclusive, non-revokable, no-cost license to use the code, algorithms, patents, and ideas in that code in our products if we so choose. You also agree the code is provided as-is and you provide no warranties as to its fitness or correctness for any purpose
 
 Copyright (c) 2016 New Relic, Inc. All rights reserved.
+
+## Contributors
+
+* [Ryan Pineo](https://github.com/ryanpineo)

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -23,6 +23,10 @@
     state: present
   when: os_name|lower == 'redhat'
 
+- name: Confirm Debian apt-transport-https is present
+  apt: name=apt-transport-https state=present
+  when: os_name|lower == 'debian'
+
 - name: setup agent repo reference
   apt_repository:
     repo: "deb https://download.newrelic.com/infrastructure_agent/linux/apt {{ os_codename }} main"


### PR DESCRIPTION
Without this apt will not be able to use the newrelic apt repository
because it uses https.