### PR TITLE
prevent errors on missing architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,4 +13,8 @@ Pull requests should:
 
 By contributing to this project you agree that you are granting New Relic a non-exclusive, non-revokable, no-cost license to use the code, algorithms, patents, and ideas in that code in our products if we so choose. You also agree the code is provided as-is and you provide no warranties as to its fitness or correctness for any purpose
 
+## Contributors
+
+- [Koen Punt](https://github.com/koenpunt)
+
 Copyright (c) 2016 New Relic, Inc. All rights reserved.

--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -25,7 +25,7 @@
 
 - name: setup agent repo reference
   apt_repository:
-    repo: "deb https://download.newrelic.com/infrastructure_agent/linux/apt {{ os_codename }} main"
+    repo: "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{ os_codename }} main"
     state: present
   when: os_name|lower == 'debian'
 


### PR DESCRIPTION
without the architecture flag it can happen that apt fails with the following error: "Unable to find expected entry 'main/binary-i386/Packages' in Release file"

And this is also the recommended way when following the install guide. (https://infrastructure.newrelic.com/accounts/0000000/install)