### PR TITLE
Handle Configuration Options as Generic Map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,5 @@ Copyright (c) 2017 New Relic, Inc. All rights reserved.
 * [danvaida](https://github.com/danvaida)
 * [Ryan Pineo](https://github.com/ryanpineo)
 * [Koen Punt](https://github.com/koenpunt)
+* [Brent Walker](https://github.com/tacchino)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ All typical interactions with `nrinfragent` will be done through role configurat
 ---
 hosts: ap_ne_1
 roles:
-  - { role: nrinfragent, nrinfragent_license_key: YOUR_LICENSE_KEY }
+  - name: nrinfragent
+    vars: 
+      nrinfragent_config: 
+        license_key: YOUR_LICENSE_KEY
+        log_file: /var/log/newrelic/nr-infra.log
+        log_to_stdout: false
 ```
 
 ## Reference
@@ -77,9 +82,12 @@ Defaults to `ansible_lsb.major_release`. Mostly used for `RedHat` family OSs. Se
 Specifies the OS codename of the installer package needed for this machine.
 Defaults to `ansible_lsb.codename`. Mostly used for `Debian` family OSs. See list in the `meta/main.yml` file for latest list.
 
-##### `nrinfragent_license_key` (REQUIRED)
+##### `nrinfragent_config` (REQUIRED)
 
-Specifies the New Relic license key to use.
+Used to populate agent configuration. At a minimum you must provide `license_key`.
+See the NewRelic documentation for current configuration options: 
+https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent)
+
 
 
 ## Limitations

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-nrinfragent_license_key: ""
 nrinfragent_state:       "latest"
 nrinfragent_version:     "*"

--- a/templates/newrelic-infra.yml.j2
+++ b/templates/newrelic-infra.yml.j2
@@ -1,1 +1,1 @@
-license_key: {{ nrinfragent_license_key }}
+{{ nrinfragent_config | to_nice_yaml }}


### PR DESCRIPTION
Refactor to take a generic map of values that will be written out to the infra config file as yaml

This allows the addition of new configuration as it becomes available without requiring
updates to the role.

I removed the specific config for license key in order to have a uniform handling of all configuration