### PR TITLE
Add options for use_static_collector and proxy to the config template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ Copyright (c) 2017 New Relic, Inc. All rights reserved.
 * [danvaida](https://github.com/danvaida)
 * [Ryan Pineo](https://github.com/ryanpineo)
 * [Koen Punt](https://github.com/koenpunt)
-
+* [jamlen](http://github.com/jamlen)

--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Undefined by default.
 
 Specifies to use the http proxy as described in the [Configuring the Infrastructure agents](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#proxy) documentation.
 
+##### `nrinfragent_custom_attributes` (OPTIONAL)
+
+Specifies a list of custom attributes to annotate the data from the agent.
+
+For example:
+
+```
+nrinfragent_custom_attributes:
+  environment: production
+  service: login service
+  team: alpha-team
+```
+
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ Defaults to `ansible_lsb.codename`. Mostly used for `Debian` family OSs. See lis
 
 Specifies the New Relic license key to use.
 
+##### `nrinfragent_use_static_collectors` BOOL (OPTIONAL)
+
+Specifies to use the static collectors as described in the [Infrastructure agents](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks#infrastructure) documentation.
+Undefined by default.
+
+##### `nrinfragent_proxy` STRING (OPTIONAL)
+
+Specifies to use the http proxy as described in the [Configuring the Infrastructure agents](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent#proxy) documentation.
+
 
 ## Limitations
 

--- a/templates/newrelic-infra.yml.j2
+++ b/templates/newrelic-infra.yml.j2
@@ -1,1 +1,7 @@
 license_key: {{ nrinfragent_license_key }}
+{% if nrinfragent_use_static_collector is equalto true %}
+collector_url: https://static-infra-api.newrelic.com
+{% endif %}
+{% if nrinfragent_proxy is defined %}
+proxy: {{ nrinfragent_proxy }}
+{% endif %}

--- a/templates/newrelic-infra.yml.j2
+++ b/templates/newrelic-infra.yml.j2
@@ -1,5 +1,5 @@
 license_key: {{ nrinfragent_license_key }}
-{% if nrinfragent_use_static_collector is equalto true %}
+{% if nrinfragent_use_static_collector | bool %}
 collector_url: https://static-infra-api.newrelic.com
 {% endif %}
 {% if nrinfragent_proxy is defined %}

--- a/templates/newrelic-infra.yml.j2
+++ b/templates/newrelic-infra.yml.j2
@@ -5,3 +5,6 @@ collector_url: https://static-infra-api.newrelic.com
 {% if nrinfragent_proxy is defined %}
 proxy: {{ nrinfragent_proxy }}
 {% endif %}
+{% if nrinfragent_custom_attributes is defined %}
+{{ {'custom_attributes': nrinfragent_custom_attributes} | to_nice_yaml }}
+{% endif %}


### PR DESCRIPTION
Allow the use of the static IP collectors, as per the [documentation](https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks#infrastructure)