### PR TITLE
Force import of gpg repo key

### DIFF
--- a/tasks/agent.yml
+++ b/tasks/agent.yml
@@ -45,6 +45,11 @@
     state: present
     description: New Relic Infrastructure
   when: nrinfragent_os_name|lower == 'redhat'
+  register: setup_agent_repo
+
+- name: run make cache to actually import gpg key
+  command: "yum -q makecache -y --disablerepo='*' --enablerepo='New-Relic-Infrastructure'"
+  when: nrinfragent_os_name|lower == 'redhat' and setup_agent_repo.changed
 
 - name: install agent
   yum:


### PR DESCRIPTION
Basically: https://github.com/ansible/ansible/issues/20711

Yum doesn't actually import the key. It'll ask for key import confirmation the next time it is applicable, failing with:

```
fatal: [10.100.40.89]: FAILED! => {"changed": false, "failed": true, "msg": "Failure talking to yum: failure: repodata/repomd.xml from New-Relic-Infrastructure: [Errno 256] No more mirrors to try.\nhttps://downl
oad.newrelic.com/infrastructure_agent/linux/yum/el/7/x86_64/repodata/repomd.xml: [Errno -1] repomd.xml signature could not be verified for New-Relic-Infrastructure"}
```
The `yum makecache` forces the import, but only when the repo has been changed.

An `update_cache: yes` on the `yum` task may also fix this, but I have no time to check that now, and it would slow the Ansible run.