### PR TITLE
Use correct Yum repository URL on Amazon Linux

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -7,6 +7,7 @@ provisioner:
   hosts: test-kitchen
   ansible_verbose: true
   ansible_verbosity: 2
+  require_ansible_omnibus: true
   require_chef_for_busser: false
   require_chef_omnibus: false
   playbook: test/integration/default/default.yml
@@ -21,6 +22,9 @@ platforms:
   - name: ubuntu-12.04
   - name: ubuntu-14.04
   - name: ubuntu-16.04
+  - name: amazon
+    driver:
+      box: winky/amazonlinux-2
 
 suites:
   - name: default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the `nrinfragent` Ansible role.
 
+## 0.3.1 (2018-04-03)
+
+BUG FIXES:
+
+* Fix Yum repository URL for Amazon Linux
+
 ## 0.3.0 (2018-03-12)
 
 IMPROVEMENTS:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: setup agent repo reference
   yum_repository:
-    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ nrinfragent_os_version }}/x86_64"
+    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ (ansible_distribution == 'Amazon') | ternary('7', nrinfragent_os_version) }}/x86_64"
     gpgcheck: yes
     gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     name: 'New-Relic-Infrastructure'


### PR DESCRIPTION
Use "7" instead of the `os_version` if we detect Amazon.

Add Amazon to the .kitchen.yml.