### PR TITLE
Set default for license key value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the `nrinfragent` Ansible role.
 
+## 0.3.3 (2018-05-14)
+
+BUG FIXES:
+
+* Set default for license key
+
 ## 0.3.2 (2018-04-30)
 
 IMPROVEMENTS:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 nrinfragent_state: "latest"
 nrinfragent_version: "*"
-nrinfragent_config: {}
+nrinfragent_config:
+  license_key: YOUR_LICENSE_KEY


### PR DESCRIPTION
This caused confusing output, so set the default to something that will fail more clearly.

Fixes #45.