### PR TITLE
 Change yum repository name to newrelic-infra

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,4 @@ Once Molecule is installed, use `molecule test` to run the tests.
 * [Rutger de Knijf](https://github.com/rdeknijf)
 * [Ryan Pineo](https://github.com/ryanpineo)
 * [Ruben Hervas](https://github.com/xino12)
+* [Johannes Hartmann](https://github.com/jojo221119)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,7 +43,7 @@
     baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ (ansible_distribution == 'Amazon') | ternary('6', nrinfragent_os_version) }}/x86_64"
     gpgcheck: "yes"
     gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
-    name: 'New-Relic-Infrastructure'
+    name: 'newrelic-infra'
     repo_gpgcheck: "yes"
     state: present
     description: New Relic Infrastructure
@@ -62,7 +62,7 @@
   register: infra_agent_zypper_repo
 
 - name: run make cache to actually import gpg key
-  command: "yum -q makecache -y --disablerepo='*' --enablerepo='New-Relic-Infrastructure'"
+  command: "yum -q makecache -y --disablerepo='*' --enablerepo='newrelic-infra'"
   when: nrinfragent_os_name|lower == 'redhat' and setup_agent_repo.changed
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
Change the name of the yum repository to comply with installation instructions provided by New Relic. See RedHat installation steps on the following link: https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/install-infrastructure-linux