### PR TITLE
Add variables to customize service state and service enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ The state of the infrastructure integrations version pacakge. By default it's
 `absent`, which doesn't install the package; you can change it to `latest` or
 `present`.
 
+##### `nrinfragent_service_state` (OPTIONAL)
+Specifies the state of the newrelic-infra service after installation.
+Defaults to `started` which ensures the service will be running. You can change it to `stopped` to just install it but don't start it in this moment.
+
+##### `nrinfragent_service_enabled` (OPTIONAL)
+Specifies if the service will be enabled (start during boot).
+Defauts to `yes`, you can change it to `no` to prevent the service to automatically start on boot.
+
 ###### DEPRECATED
 
 Specify the license key. For backward compatibility. Use `license_key` in

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
 nrinfraintegrations_state: "absent"
 nrinfragent_state: "latest"
+nrinfragent_service_enabled: "yes"
+nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,4 @@
 
 - name: restart newrelic-infra
   service: name=newrelic-infra state=restarted
+  when: nrinfragent_service_state != "stopped"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,5 +100,8 @@
   when: nrinfragent_state != "absent"
 
 - name: setup agent service
-  service: name=newrelic-infra state=started enabled=yes
+  service:
+    name: newrelic-infra
+    state: "{{ nrinfragent_service_state }}"
+    enabled: "{{ nrinfragent_service_enabled }}"
   when: nrinfragent_state != "absent"


### PR DESCRIPTION
Implements #60 

This PR adds two new variables: `nrinfragent_service_enabled` and `nrinfragent_service_state` to manage the agent service state, allowing to just install the agent without running it and also allowing to disable it to prevent it to starting on the next boot