### PR TITLE
Deprecate metapackge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file is used to list changes made in each version of the `nrinfragent` Ansible role.
 
+## 0.7.0
+
+IMPROVEMENTS:
+
+* Add support for installing individual integrations. The role switches from
+  the deprecated `newrelic-infra-integrations` package (which only
+  included 5 integrations), to the `nri-*` individual integration packages.
+
 ## 0.6.1 (2019-01-09)
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -81,16 +81,52 @@ Defaults to `started` which ensures the service will be running. You can change 
 ##### `nrinfragent_service_enabled` (OPTIONAL)
 Specifies if the service will be enabled (start during boot).
 Defauts to `yes`, you can change it to `no` to prevent the service to automatically start on boot.
+
 ##### `nrinfragent_integrations` (OPTIONAL)
 
-List of the infrastructure integrations to be installed. Each package sould provide
-`name` (e.g.: nri-nginx) and `state`. By default the state it's
-`absent`, which doesn't install the package; you can change it to `latest` or
-`present`.
-e.g.
+Specifies the infrastructure integrations to be installed. The list of available
+integrations can be found [here][1].
+
+Each package sould provide the `name` and `state`. The integrations package name is located
+in the **Install and activate** section of the individual integrations docs. They use the
+following convention: name of the service with the `nri-` prefix (`nri-apache`, `nri-redis`, ...). 
+By default the state it's `absent`, which doesn't install the package; you can change it to
+`latest` or `present`.
+
+configuration e.g.
+
+```
 nrinfragent_integrations:
   - { name: nri-nginx, state: "latest" }
   - { name: nri-mysql, state: "absent" }
+```
+
+The source code for each integration is available on [newrelic's github organization][2].
+
+#### Removing newrelic-infra-integrations package and its bundled integrations
+
+**NOTE** *This only applies if you have the `newrelic-infra-integrations` 
+package installed*
+
+If you had installed the `newrelic-infra-integrations` package, 
+could be because you were using the previous versions of this module, or you 
+installed it some other way; and you want to do some cleanup by
+removing it or any of the following integrations (the ones that came bundle
+with it):
+
+- nri-redis
+- nri-cassandra
+- nri-apache
+- nri-nginx
+- nri-mysql
+
+You have to add `newrelic-infra-integrations` as the first item of the 
+`nrinfragent_integrations` with e desired state `absent`.
+
+```
+nrinfragent_integrations:
+  - { name: newrelic-infra-integrations, state: "absent" }
+```
 
 ###### DEPRECATED
 
@@ -120,3 +156,6 @@ Specify the license key. For backward compatibility. Use `license_key` in
   * 12
 
 Copyright (c) 2018 New Relic, Inc. All rights reserved.
+
+[1]: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list
+[2]: https://github.com/search?l=&p=1&q=nri-+user%3Anewrelic&ref=advsearch&type=Repositories&utf8=%E2%9C%93

--- a/README.md
+++ b/README.md
@@ -74,17 +74,16 @@ See the NewRelic documentation for current configuration options:
 
 ##### `nrinfragent_license_key`
 
-The state of the infrastructure integrations version pacakge. By default it's
+##### `nrinfragent_integrations` (OPTIONAL)
+
+List of the infrastructure integrations to be installed. Each package sould provide
+`name` (e.g.: nri-nginx) and `state`. By default the state it's
 `absent`, which doesn't install the package; you can change it to `latest` or
 `present`.
-
-##### `nrinfragent_service_state` (OPTIONAL)
-Specifies the state of the newrelic-infra service after installation.
-Defaults to `started` which ensures the service will be running. You can change it to `stopped` to just install it but don't start it in this moment.
-
-##### `nrinfragent_service_enabled` (OPTIONAL)
-Specifies if the service will be enabled (start during boot).
-Defauts to `yes`, you can change it to `no` to prevent the service to automatically start on boot.
+e.g.
+nrinfragent_integrations:
+  - { name: nri-nginx, state: "latest" }
+  - { name: nri-mysql, state: "absent" }
 
 ###### DEPRECATED
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ See the NewRelic documentation for current configuration options:
 
 ##### `nrinfragent_license_key`
 
+##### `nrinfragent_service_state` (OPTIONAL)
+Specifies the state of the newrelic-infra service after installation.
+Defaults to `started` which ensures the service will be running. You can change it to `stopped` to just install it but don't start it in this moment.
+
+##### `nrinfragent_service_enabled` (OPTIONAL)
+Specifies if the service will be enabled (start during boot).
+Defauts to `yes`, you can change it to `no` to prevent the service to automatically start on boot.
 ##### `nrinfragent_integrations` (OPTIONAL)
 
 List of the infrastructure integrations to be installed. Each package sould provide

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ See the NewRelic documentation for current configuration options:
 
 ##### `nrinfragent_license_key`
 
-##### `nrinfraintegrations_state` (OPTIONAL)
-
 The state of the infrastructure integrations version pacakge. By default it's
 `absent`, which doesn't install the package; you can change it to `latest` or
 `present`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,7 @@ nrinfragent_config:
 nrinfragent_integrations:
   - { name: nri-nginx, state: "absent" }
   - { name: nri-mysql, state: "absent" }
+  - { name: nri-cassandra, state: "absent" }
+  - { name: nri-apache, state: "absent" }
+  - { name: nri-redis, state: "absent" }
+  - { name: newrelic-infra-integrations, state: "absent" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,9 @@
 ---
-nrinfraintegrations_state: "absent"
 nrinfragent_state: "latest"
 nrinfragent_service_enabled: "yes"
 nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY
+nrinfragent_integrations:
+  - { name: nri-nginx, state: "absent" }
+  - { name: nri-mysql, state: "absent" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,10 +4,4 @@ nrinfragent_service_enabled: "yes"
 nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY
-nrinfragent_integrations:
-  - { name: nri-nginx, state: "absent" }
-  - { name: nri-mysql, state: "absent" }
-  - { name: nri-cassandra, state: "absent" }
-  - { name: nri-apache, state: "absent" }
-  - { name: nri-redis, state: "absent" }
-  - { name: newrelic-infra-integrations, state: "absent" }
+nrinfragent_integrations: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,8 +88,9 @@
 
 - name: install integrations
   package:
-    name: "newrelic-infra-integrations"
-    state: "{{ nrinfraintegrations_state }}"
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+  with_items: "{{ nrinfragent_integrations }}"
 
 - name: setup agent config
   template:


### PR DESCRIPTION
This PR will deprecate the `newrelic-infra-integrations` package. Instead of this package, a new option was added to specify the list of integrations to be installed:

e.g.
nrinfragent_integrations:
  - { name: nri-nginx, state: "latest" }
  - { name: nri-mysql, state: "latest" }