### PR TITLE
Fix duplicate license_key and save agent config when installed from tar package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ Used to populate agent configuration. At a minimum you must provide `license_key
 See the NewRelic documentation for current configuration options:
 [https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent](https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/configuration/configure-infrastructure-agent)
 
-##### `nrinfragent_license_key`
-
 ##### `nrinfragent_service_state` (OPTIONAL)
 Specifies the state of the newrelic-infra service after installation.
 Defaults to `started` which ensures the service will be running. You can change it to `stopped` to just install it but don't start it in this moment.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY
 nrinfragent_integrations: []
+#nrinfragent_tarball_version: "1.3.27"
 nrinfragent_tarball_url: "http://download.newrelic.com/infrastructure_agent/binaries/linux/{{ nrinfragent_architecture }}/newrelic-infra_linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}.tar.gz"
 nrinfragent_tarball_download_dir: "/opt"
 nrinfragent_tarball_user: "root"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY
 nrinfragent_integrations: []
-#nrinfragent_tarball_version: "1.3.27"
 nrinfragent_tarball_url: "http://download.newrelic.com/infrastructure_agent/binaries/linux/{{ nrinfragent_architecture }}/newrelic-infra_linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}.tar.gz"
 nrinfragent_tarball_download_dir: "/opt"
 nrinfragent_tarball_user: "root"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,6 @@ nrinfragent_service_state: "started"
 nrinfragent_config:
   license_key: YOUR_LICENSE_KEY
 nrinfragent_integrations: []
-nrinfragent_license_key: null
 nrinfragent_tarball_url: "http://download.newrelic.com/infrastructure_agent/binaries/linux/{{ nrinfragent_architecture }}/newrelic-infra_linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}.tar.gz"
 nrinfragent_tarball_download_dir: "/opt"
 nrinfragent_tarball_user: "root"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,11 +3,3 @@
 - name: restart newrelic-infra
   service: name=newrelic-infra state=restarted
   when: nrinfragent_service_state != "stopped"
-
-- name: running installer
-  command: ./installer.sh
-  args:
-    chdir: "/opt/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/newrelic-infra/"
-  environment:
-    NRIA_LICENSE_KEY: "{{ nrinfragent_config['license_key'] | default('') }}"
-  become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,13 +9,5 @@
   args:
     chdir: "/opt/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/newrelic-infra/"
   environment:
-    NRIA_BIN_DIR: "{{ nrinfragent_tarball_bin_dir | default('') }}"
-    NRIA_MODE: "{{ nrinfragent_tarball_mode | default('') }}"
-    NRIA_USER: "{{ nrinfragent_tarball_user | default('') }}"
-    NRIA_CONFIG_FILE: "{{ nrinfragent_tarball_config_file | default('') }}"
-    NRIA_PID_FILE: "{{ nrinfragent_tarball_pid_file | default('') }}"
-    NRIA_AGENT_DIR: "{{ nrinfragent_tarball_agent_dir | default('') }}"
-    NRIA_PLUGIN_DIR: "{{ nrinfragent_tarball_plugin_dir | default('') }}"
-    NRIA_LOG_FILE: "{{ nrinfragent_tarball_log_file | default('') }}"
-    NRIA_LICENSE_KEY: "{{ nrinfragent_license_key | default('') }}"
+    NRIA_LICENSE_KEY: "{{ nrinfragent_config['license_key'] | default('') }}"
   become: true

--- a/tasks/install_targz.yml
+++ b/tasks/install_targz.yml
@@ -5,7 +5,6 @@
   when: vars[item] is undefined or not vars[item]
   loop:
     - nrinfragent_tarball_version
-    - nrinfragent_license_key
 
 - name: downloading bundled agent file
   get_url:

--- a/tasks/install_targz.yml
+++ b/tasks/install_targz.yml
@@ -23,5 +23,26 @@
     dest: "{{ nrinfragent_tarball_download_dir }}/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/"
     remote_src: yes
     creates: "{{ nrinfragent_tarball_download_dir }}/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/newrelic-infra/"
-  notify:
-    - running installer
+  register: archive_contents
+
+- name: running installer
+  command: ./installer.sh
+  args:
+    chdir: "/opt/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/newrelic-infra/"
+  environment:
+    NRIA_BIN_DIR: "{{ nrinfragent_tarball_bin_dir | default('') }}"
+    NRIA_MODE: "{{ nrinfragent_tarball_mode | default('') }}"
+    NRIA_USER: "{{ nrinfragent_tarball_user | default('') }}"
+    NRIA_CONFIG_FILE: "{{ nrinfragent_tarball_config_file | default('') }}"
+
+    NRIA_LICENSE_KEY: "{{ nrinfragent_config['license_key'] | default('') }}"
+  become: true
+  when: archive_contents is defined and archive_contents.changed == True
+
+- name: save config options to file
+  lineinfile:
+    'dest=/etc/newrelic-infra.yml
+    regexp="^{{ item.key }}: "
+    line="{{ item.key }}: {{ item.value }}"'
+  with_items: "{{ lookup('dict', nrinfragent_config) }}"
+  notify: restart newrelic-infra


### PR DESCRIPTION
This PR will 
- fix the issue with duplicate license_key option saved into the config file
- save a config fill with the agent options when install the agent from tar package