### PR TITLE
Add Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file is used to list changes made in each version of the `nrinfragent` Ansible role.
 
+## 0.9.0 (2019-06-27)
+
+IMPROVEMENTS:
+
+* Add support for Windows
+
 ## 0.8.0 (2019-05-27)
 
 IMPROVEMENTS:
@@ -13,12 +19,12 @@ IMPROVEMENTS:
 
 IMPROVEMENTS:
 
-* Add support for installing individual integrations. The role 
-  switches from the deprecated `newrelic-infra-integrations` package (which 
-  only included 5 integrations), to the `nri-*` individual integration 
+* Add support for installing individual integrations. The role
+  switches from the deprecated `newrelic-infra-integrations` package (which
+  only included 5 integrations), to the `nri-*` individual integration
   packages. The `nrinfraintegrations_state` variable was removed, a new
-  `nrinfragent_integrations` variable was added for specifying individual 
-  integrations. 
+  `nrinfragent_integrations` variable was added for specifying individual
+  integrations.
 
 ## 0.6.1 (2019-01-09)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,4 @@ Once Molecule is installed, use `molecule test` to run the tests.
 * [Ruben Hervas](https://github.com/xino12)
 * [Johannes Hartmann](https://github.com/jojo221119)
 * [Alejandro Do Nascimento](https://github.com/alejandrodnm)
+* [Asif Shaikh](https://github.com/ripclawffb)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ See the NewRelic documentation for current configuration options:
 
 ##### `nrinfragent_license_key`
 
+##### `nrinfragent_choco_version` (OPTIONAL)
+Specifies the version of newrelice infra chocolatey package to install on Windows. Can be used to pin the version or upgrade the agent.
+
 ##### `nrinfragent_service_state` (OPTIONAL)
 Specifies the state of the newrelic-infra service after installation.
 Defaults to `started` which ensures the service will be running. You can change it to `stopped` to just install it but don't start it in this moment.
@@ -89,7 +92,7 @@ integrations can be found [here][1].
 
 Each package sould provide the `name` and `state`. The integrations package name is located
 in the **Install and activate** section of the individual integrations docs. They use the
-following convention: name of the service with the `nri-` prefix (`nri-apache`, `nri-redis`, ...). 
+following convention: name of the service with the `nri-` prefix (`nri-apache`, `nri-redis`, ...).
 By default the state it's `absent`, which doesn't install the package; you can change it to
 `latest` or `present`.
 
@@ -105,11 +108,11 @@ The source code for each integration is available on [newrelic's github organiza
 
 #### Removing newrelic-infra-integrations package and its bundled integrations
 
-**NOTE** *This only applies if you have the `newrelic-infra-integrations` 
+**NOTE** *This only applies if you have the `newrelic-infra-integrations`
 package installed*
 
-If you had installed the `newrelic-infra-integrations` package, 
-could be because you were using the previous versions of this module, or you 
+If you had installed the `newrelic-infra-integrations` package,
+could be because you were using the previous versions of this module, or you
 installed it some other way; and you want to do some cleanup by
 removing it or any of the following integrations (the ones that came bundle
 with it):
@@ -120,7 +123,7 @@ with it):
 - nri-nginx
 - nri-mysql
 
-You have to add `newrelic-infra-integrations` as the first item of the 
+You have to add `newrelic-infra-integrations` as the first item of the
 `nrinfragent_integrations` with the desired state `absent`.
 
 ```
@@ -155,6 +158,8 @@ Specify the license key. For backward compatibility. Use `license_key` in
   * 7 Wheezy
 * SUSE Linux Enterprise
   * 12
+* Windows
+  * All
 
 # Release to Ansible Galaxy
 
@@ -162,7 +167,7 @@ To release a new version to [Ansible Galaxy][3] follow this steps:
 
 * Update the [CHANGELOG.md](CHANGELOG.md)
 * Create a new Github release.
-* Make sure the version is imported into [Ansible Galaxy][3], if there is any issue, ask one of 
+* Make sure the version is imported into [Ansible Galaxy][3], if there is any issue, ask one of
   the project owners.
 
 Copyright (c) 2018 New Relic, Inc. All rights reserved.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,15 @@
 ---
 
 - name: restart newrelic-infra
-  service: name=newrelic-infra state=restarted
+  service:
+    name: newrelic-infra
+    state: restarted
+  when: nrinfragent_service_state != "stopped"
+
+- name: restart newrelic-infra (windows)
+  win_service:
+    name: newrelic-infra
+    state: restarted
   when: nrinfragent_service_state != "stopped"
 
 - name: running installer

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -26,7 +26,11 @@ galaxy_info:
         - trusty
         - xenial
         - bionic
-  categories:
-    - cloud:ec2
+    - name: Windows
+      versions:
+        - all
+  galaxy_tags:
+    - cloud
+    - ec2
     - monitoring
     - system

--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -1,10 +1,13 @@
 ---
-- name: confirm RedHat lsb util is present
-  yum: name=redhat-lsb-core state=present
+- name: confirm redhat lsb util is present
+  yum:
+    name: redhat-lsb-core
+    state: present
   when: nrinfragent_os_name|lower == 'redhat'
 
 - name: reread ansible_lsb facts
-  setup: filter=ansible_lsb*
+  setup:
+    filter: ansible_lsb*
   when: nrinfragent_os_name|lower == 'redhat'
 
 - name: setup agent repo keys
@@ -85,12 +88,22 @@
   package:
     name: "newrelic-infra"
     state: "{{ nrinfragent_state }}"
+  when: nrinfragent_os_name|lower != 'windows'
 
 - name: install integrations
   package:
     name: "{{ item.name }}"
     state: "{{ item.state }}"
   with_items: "{{ nrinfragent_integrations }}"
+  when: nrinfragent_os_name|lower != 'windows'
+
+- name: install agent (windows)
+  win_chocolatey:
+    name: newrelic-infra
+    state: "{{ nrinfragent_state }}"
+    version: "{{ nrinfragent_choco_version | default(omit) }}"
+  when:
+    - nrinfragent_os_name|lower == 'windows'
 
 - name: setup agent config
   template:
@@ -98,11 +111,33 @@
     dest: /etc/newrelic-infra.yml
     mode: 0600
   notify: restart newrelic-infra
-  when: nrinfragent_state != "absent"
+  when:
+    - nrinfragent_state != "absent"
+    - nrinfragent_os_name|lower != 'windows'
+
+- name: setup agent config
+  win_template:
+    src: newrelic-infra.yml.j2
+    dest: '%ProgramFiles%\New Relic\newrelic-infra\newrelic-infra.yml'
+  notify: restart newrelic-infra (windows)
+  when:
+    - nrinfragent_state != "absent"
+    - nrinfragent_os_name|lower == 'windows'
 
 - name: setup agent service
   service:
     name: newrelic-infra
     state: "{{ nrinfragent_service_state }}"
     enabled: "{{ nrinfragent_service_enabled }}"
-  when: nrinfragent_state != "absent"
+  when:
+    - nrinfragent_state != "absent"
+    - nrinfragent_os_name|lower != 'windows'
+
+- name: setup agent service
+  win_service:
+    name: newrelic-infra
+    state: "{{ nrinfragent_service_state }}"
+    enabled: "{{ nrinfragent_service_enabled }}"
+  when:
+    - nrinfragent_state != "absent"
+    - nrinfragent_os_name|lower == 'windows'

--- a/tasks/install_targz.yml
+++ b/tasks/install_targz.yml
@@ -22,7 +22,7 @@
   unarchive:
     src: "{{ nrinfragent_tarball_download_dir }}/newrelic-infra_linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}.tar.gz"
     dest: "{{ nrinfragent_tarball_download_dir }}/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/"
-    remote_src: yes
+    remote_src: true
     creates: "{{ nrinfragent_tarball_download_dir }}/newrelic_infra/linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}/newrelic-infra/"
   notify:
     - running installer


### PR DESCRIPTION
I recently created a chocolatey package to ease the deployment and version management of newrelic-infra for the Windows OS. I wanted to add support to this Ansible Galaxy role so others may benefit as well.