### PR TITLE
adjusted so that installing in a disabled state works for windows hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Defaults to `started` which ensures the service will be running. You can change 
 
 ##### `nrinfragent_service_enabled` (OPTIONAL)
 Specifies if the service will be enabled (start during boot).
-Defauts to `yes`, you can change it to `no` to prevent the service to automatically start on boot.
+Defauts to `yes`, you can change it to `no` to prevent the service to automatically start on boot. For windows hosts, it needs to be set to `disabled` to prevent automatic start on boot.
 
 ##### `nrinfragent_integrations` (OPTIONAL)
 

--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -115,7 +115,7 @@
     - nrinfragent_state != "absent"
     - nrinfragent_os_name|lower != 'windows'
 
-- name: setup agent config
+- name: setup agent config (windows)
   win_template:
     src: newrelic-infra.yml.j2
     dest: '%ProgramFiles%\New Relic\newrelic-infra\newrelic-infra.yml'
@@ -133,11 +133,11 @@
     - nrinfragent_state != "absent"
     - nrinfragent_os_name|lower != 'windows'
 
-- name: setup agent service
+- name: setup agent service (windows)
   win_service:
     name: newrelic-infra
     state: "{{ nrinfragent_service_state }}"
-    enabled: "{{ nrinfragent_service_enabled }}"
+    start_mode: "{{ nrinfragent_service_enabled }}"
   when:
     - nrinfragent_state != "absent"
     - nrinfragent_os_name|lower == 'windows'

--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -137,7 +137,7 @@
   win_service:
     name: newrelic-infra
     state: "{{ nrinfragent_service_state }}"
-    start_mode: "{{ nrinfragent_service_enabled }}"
+    start_mode: "{{ ( nrinfragent_service_enabled == true ) | ternary('auto','manual') }}"
   when:
     - nrinfragent_state != "absent"
     - nrinfragent_os_name|lower == 'windows'


### PR DESCRIPTION
The win_service module does not have an "enabled" option, it's equivalent is called "start_mode".

To identify relevant steps in playbook, "(windows)" has been appended to task names which were the same between linux/windows to make them unique.

ReadMe adjusted to reflect slightly different option for disable in windows