### PR TITLE
adding a variable to allow users to not log the config values since l…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,4 @@ nrinfragent_integrations: []
 nrinfragent_tarball_url: "http://download.newrelic.com/infrastructure_agent/binaries/linux/{{ nrinfragent_architecture }}/newrelic-infra_linux_{{ nrinfragent_tarball_version }}_{{ nrinfragent_architecture }}.tar.gz"
 nrinfragent_tarball_download_dir: "/opt"
 nrinfragent_tarball_user: "root"
+nrinfragent_hide_config_values: false

--- a/tasks/install_targz.yml
+++ b/tasks/install_targz.yml
@@ -45,4 +45,5 @@
     regexp="^{{ item.key }}: "
     line="{{ item.key }}: {{ item.value }}"'
   with_items: "{{ lookup('dict', nrinfragent_config) }}"
+  no_log: "{{ nrinfragent_hide_config_values }}"
   notify: restart newrelic-infra


### PR DESCRIPTION
adding a `nrinfragent_hide_config_values` variable to allow users to not log the config values since license key is a secret.

example packer output for the change with `nrinfragent_hide_config_values: true`:
`amazon-ebs: TASK [newrelic.newrelic-infra : save config options to file] *******************
    amazon-ebs: task path: /tmp/packer-provisioner-ansible-local/5dd6d8b7-2d01-22b3-072b-b8ca96aa5922/roles/newrelic.newrelic-infra/tasks/install_targz.yml:42
    amazon-ebs: Thursday 21 November 2019  12:39:48 -0600 (0:00:00.033)       0:02:21.143 *****
    amazon-ebs: skipping: [127.0.0.1] => (item=None)  => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
    amazon-ebs: skipping: [127.0.0.1] => (item=None)  => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
    amazon-ebs: skipping: [127.0.0.1] => (item=None)  => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}`
