### PR TITLE
meta/main.yml update ansible_min_version: 2.5

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: Role to install New Relic Infrastructure agent
   company: New Relic, Inc.
   license: All components of this product are Copyright (c) 2016 New Relic, Inc.  All rights reserved.
-  min_ansible_version: 2.1
+  min_ansible_version: 2.5
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
References: #79 

**Summary**
The role relies on modules that require a minimum Ansible version of 2.5.

Refer to #79 for screenshots.
