### PR TITLE
Idempotency fix

### DIFF
--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -17,12 +17,19 @@
     - nrinfragent_os_name != 'windows'
     - ansible_python_version is version('3.0', '>=')
 
+- name: Stat newrelic-infra.yml config file
+  stat:
+    path: "{{ nrinfragent_config_path }}"
+  register: nrinfragent_config_stat
+
 - name: Ensure newrelic-infra.yml exists
   file:
     path: "{{ nrinfragent_config_path }}"
     state: touch
     mode: 0600
-  when: nrinfragent_os_name != 'windows'
+  when:
+    - nrinfragent_os_name != 'windows'
+    - nrinfragent_config_stat.stat.exists == false or nrinfragent_config_stat.stat.mode != '0600'
 
 - name: Setup agent config *NIX
   merge_yaml:


### PR DESCRIPTION
The task `Ensure newrelic-infra.yml exists` in the `configure_agent.yml` file is not idempotent because the touch operation updates the file atime and mtime.

With this change we check (with stat) if the file needs to be touched (because it does not exist or it has wrong mode).