### PR TITLE
Support aarch64 for yum based distros

### DIFF
--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -51,7 +51,7 @@
 
 - name: setup agent repo reference
   yum_repository:
-    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ (ansible_service_mgr == 'upstart') | ternary('6', '7') }}/x86_64"
+    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ (ansible_service_mgr == 'upstart') | ternary('6', '7') }}/{{ ansible_architecture }}"
     gpgcheck: "yes"
     gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     name: 'newrelic-infra'
@@ -63,7 +63,7 @@
 
 - name: setup agent repo reference
   yum_repository:
-    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ nrinfragent_os_version }}/x86_64"
+    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ nrinfragent_os_version }}/{{ ansible_architecture }}"
     gpgcheck: "yes"
     gpgkey: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
     name: 'newrelic-infra'


### PR DESCRIPTION
this is similar to #141 but for RedHat and Amazon Linux.

When trying to install NewRelic agent on Amazon t4g instances using Amazon Linux 2, the playbook failed because it could not find the package.

The package does exist inside the repository, but the configuration was pointing to the wrong architecture since it was hardcoded to only x86_64.

This change relies on ansible_architecture variable to provide the proper identifier to use in the repository URL.