### PR TITLE
Update configure_agent.yml to install on rpm (RedHat) based systems

### DIFF
--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -19,15 +19,24 @@
     - ansible_python_version is version('3.0', '>=')
     - ansible_facts['os_family'] == 'Debian
 
-- name: ensure python3-yaml is installed on rpm based systems
+- name: ensure pyYAML is installed
   package:
-    name: pyYaml
+    name: pyYAML
     state: "{{ nrinfragent_state }}"
   when:
     - nrinfragent_state != "absent"
     - nrinfragent_os_name != 'windows'
+    - ansible_python_version is version('3.0', '<')
+    - ansible_facts['os_family'] == 'RedHat'
+
+- name: ensure pyYAML is installed via pip
+  pip:
+    name: PyYAML
+  when:
+    - nrinfragent_state != "absent"
+    - nrinfragent_os_name != "windows"
     - ansible_python_version is version('3.0', '>=')
-    - ansible_facts['os_family'] == 'Redhat
+    - ansible_facts['os_family'] == 'RedHat'
 
 - name: Stat newrelic-infra.yml config file
   stat:

--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -17,7 +17,7 @@
     - nrinfragent_state != "absent"
     - nrinfragent_os_name != 'windows'
     - ansible_python_version is version('3.0', '>=')
-    - ansible_facts['os_family'] == 'Debian
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: ensure pyYAML is installed
   package:

--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -7,6 +7,7 @@
     - nrinfragent_state != "absent"
     - nrinfragent_os_name != 'windows'
     - ansible_python_version is version('3.0', '<')
+    - ansible_facts['os_family'] == 'Debian'
 
 - name: ensure python3-yaml is installed
   package:
@@ -16,6 +17,17 @@
     - nrinfragent_state != "absent"
     - nrinfragent_os_name != 'windows'
     - ansible_python_version is version('3.0', '>=')
+    - ansible_facts['os_family'] == 'Debian
+
+- name: ensure python3-yaml is installed on rpm based systems
+  package:
+    name: pyYaml
+    state: "{{ nrinfragent_state }}"
+  when:
+    - nrinfragent_state != "absent"
+    - nrinfragent_os_name != 'windows'
+    - ansible_python_version is version('3.0', '>=')
+    - ansible_facts['os_family'] == 'Redhat
 
 - name: Stat newrelic-infra.yml config file
   stat:


### PR DESCRIPTION
Hi,

As written the tasks to install the yaml dependency is Debian specific.

I've updated the tasks to install python-yaml/python3-yaml to be Debian specific and added 2 tasks to install the equivalent package (PyYAML) via rpm (Python 2) or pip (Python 3) on RedHat based systems.

This fixes 'no such package' errors on Amazon Linux 2 and the New Relic agent is successfully installed via Ansible on my test system.

Thanks,