### PR TITLE
Fix #172: Skip stat module on Windows targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ Contributions are always welcome. Before contributing please read the
 [code of conduct](./CODE_OF_CONDUCT.md) and [search the issue tracker](issues); your issue may have already been discussed or fixed in `main`. To contribute,
 [fork](https://help.github.com/articles/fork-a-repo/) this repository, commit your changes, and [send a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
+We require all of your commits to be GPG-signed.
+
 Note that our [code of conduct](./CODE_OF_CONDUCT.md) applies to all platforms and venues related to this project; please follow it in all your interactions with the project and its participants.
 
 ## Feature Requests

--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -21,6 +21,8 @@
   stat:
     path: "{{ nrinfragent_config_path }}"
   register: nrinfragent_config_stat
+  when:
+    - nrinfragent_os_name != 'windows'
 
 - name: Ensure newrelic-infra.yml exists
   file:


### PR DESCRIPTION
The ansible.builtin.stat module is for non-Windows targets only. It fails on Windows.

Fix #172