### PR TITLE
Enabled 'stat newrelic-infra.yml config file' on windows

### DIFF
--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -21,6 +21,13 @@
   stat:
     path: "{{ nrinfragent_config_path }}"
   register: nrinfragent_config_stat
+  when: nrinfragent_os_name != 'windows'
+
+- name: (Windows) Stat newrelic-infra.yml config file
+  win_stat:
+    path: "{{ nrinfragent_config_path }}"
+  register: nrinfragent_config_stat
+  when: nrinfragent_os_name == 'windows'
 
 - name: Ensure newrelic-infra.yml exists
   file:


### PR DESCRIPTION
The task 'stat newrelic-infra.yml config file' didn't work on Windows hosts. The same task added with win_ module and set the appropriate conditionals on this new and the existing tasks.