### PR TITLE
Add winevtlog as another input plugin for logging on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Used to generate logging file. At a minimum you must provide
 vars:
   nrinfragent_logging:
     - name: Name of the logs that you want to forward to newrelic one [required]
-      source_type: type of the logs you want to forward - file/systemd/syslog/tcp/winlog [required]
+      source_type: type of the logs you want to forward - file/systemd/syslog/tcp/winlog/winevtlog [required]
       source_value: ONLY FILE/SYSTEMD - value of the source type https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent/#log-source-required
       syslog: [required if source_type is syslog]
         uri: Syslog socket. Format varies depending on the protocol
@@ -338,6 +338,10 @@ vars:
         uri: TCP/IP socket to listen for incoming data. The URI format is tcp://LISTEN_ADDRESS:PORT
         format: format of the data. It can be json or none.
         separator: If format - none is used, you can define a separator string for splitting records (default - \n).
+      winevtlog: [required if source_type is winevtlog]
+        channel: name of the channel logs will be collected from.
+        collect_eventids: a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.
+        exclude_eventids: a list of Windows Event IDs to be excluded from collection. Event ID ranges are supported.
       winlog: [required if source_type is winlog]
         channel: name of the channel logs will be collected from.
         collect_eventids: a list of Windows Event IDs to be collected and forwarded to New Relic. Event ID ranges are supported.

--- a/templates/newrelic-logging.yml.j2
+++ b/templates/newrelic-logging.yml.j2
@@ -24,12 +24,25 @@ logs:
       {% endif -%}
   {% elif nrinfragent_logging[log].source_type == 'winlog' and nrinfragent_logging[log].winlog is defined %}
     winlog:
+      {% if nrinfragent_logging[log].winlog.channel is defined -%}
       channel: {{ nrinfragent_logging[log].winlog.channel }}
+      {% endif -%}
       {% if nrinfragent_logging[log].winlog.collect_eventids is defined -%}
       collect-eventids: {{ nrinfragent_logging[log].winlog.collect_eventids }}
       {% endif -%}
       {% if nrinfragent_logging[log].winlog.exclude_eventids is defined -%}
       exclude-eventids: {{ nrinfragent_logging[log].winlog.exclude_eventids -}}
+      {% endif -%}
+  {% elif nrinfragent_logging[log].source_type == 'winevtlog' and nrinfragent_logging[log].winevtlog is defined %}
+    winevtlog:
+      {% if nrinfragent_logging[log].winevtlog.channel is defined -%}
+      channel: {{ nrinfragent_logging[log].winevtlog.channel }}
+      {% endif -%}
+      {% if nrinfragent_logging[log].winevtlog.collect_eventids is defined -%}
+      collect-eventids: {{ nrinfragent_logging[log].winevtlog.collect_eventids }}
+      {% endif -%}
+      {% if nrinfragent_logging[log].winevtlog.exclude_eventids is defined -%}
+      exclude-eventids: {{ nrinfragent_logging[log].winevtlog.exclude_eventids -}}
       {% endif -%}
   {% endif -%}
   {% if nrinfragent_logging[log].max_line_kb is defined %}


### PR DESCRIPTION
Hi!

This depends on https://github.com/newrelic/infrastructure-agent/pull/1125

Since fluent-bit 1.9.0 there is a new plugin to get windows logs `winevtlog`. Its output is different than the output from `winlog` so we can't replace one by another but should give the users the option to use the new one.

More information on the infrastructure-agent ticket linked above.

Regards!

https://docs.fluentbit.io/manual/pipeline/inputs/windows-event-log-winevtlog
https://fluentbit.io/announcements/v1.9.0/