### PR TITLE
Add license key variable with flattened namespace

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,7 @@ nrinfragent_service_state: "started"
 # log_file: /tmp/logs.log
 # verbose: 1
 nrinfragent_config:
-  license_key: YOUR_LICENSE_KEY
+  license_key: "{{ nrinfragent_license_key | default('YOUR_LICENSE_KEY') }}"
   proxy: ""
 
 # A variable to prevent config values from being displayed


### PR DESCRIPTION
Added extra variable `nrinfragent_license_key` which provides an optional default value for the otherwise hierarchical variable `nrinfragent_config.license_key`.

This circumvents [Issue# 1965](https://github.com/ansible/awx/issues/1965) in Ansible Tower/AWX, which prevents creating custom Credential Types that contains a dictionary-type variable.