### PR TITLE
NEWRELIC-5466 : fix Ansible version comparison

### DIFF
--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -3,14 +3,14 @@
   yum:
     name: redhat-lsb-core
     state: present
-  when: nrinfragent_os_name == 'redhat' and ansible_version.full < "2.8.0"
+  when: nrinfragent_os_name == 'redhat' and ansible_version.full is version("2.8.0", '<')
 
 - name: confirm redhat lsb util is present post2.8.0
   yum:
     name: redhat-lsb-core
     state: present
     lock_timeout: "{{ nrinfragent_yum_lock_timeout }}"
-  when: nrinfragent_os_name == 'redhat' and ansible_version.full >= "2.8.0"
+  when: nrinfragent_os_name == 'redhat' and ansible_version.full is version("2.8.0", '>=')
 
 - name: reread ansible_lsb facts
   setup:
@@ -105,34 +105,34 @@
   package:
     name: "newrelic-infra"
     state: "{{ nrinfragent_state }}"
-  when: nrinfragent_os_name != 'windows' and ansible_version.full < "2.8.0"
+  when: nrinfragent_os_name != 'windows' and ansible_version.full is version("2.8.0", '<')
 
 - name: install agent post2.8.0
   package:
     name: "newrelic-infra"
     state: "{{ nrinfragent_state }}"
-  when: nrinfragent_os_name != 'windows' and ansible_version.full >= "2.8.0" and nrinfragent_os_name != 'amazon' and nrinfragent_os_name != 'redhat'
+  when: nrinfragent_os_name != 'windows' and ansible_version.full is version("2.8.0", '>=') and nrinfragent_os_name != 'amazon' and nrinfragent_os_name != 'redhat'
 
 - name: Install agent yum
   yum:
     name: "newrelic-infra"
     state: "{{ nrinfragent_state }}"
     lock_timeout: "{{ nrinfragent_yum_lock_timeout }}"
-  when: (nrinfragent_os_name == 'redhat' or nrinfragent_os_name == 'amazon') and ansible_version.full >= "2.8.0"
+  when: (nrinfragent_os_name == 'redhat' or nrinfragent_os_name == 'amazon') and ansible_version.full is version("2.8.0", '>=')
 
 - name: install integrations pre2.8.0
   package:
     name: "{{ item.name }}"
     state: "{{ item.state }}"
   with_items: "{{ nrinfragent_integrations }}"
-  when: nrinfragent_os_name != 'windows' and ansible_version.full < "2.8.0"
+  when: nrinfragent_os_name != 'windows' and ansible_version.full is version("2.8.0", '<')
 
 - name: Install integrations post2.8.0
   package:
     name: "{{ item.name }}"
     state: "{{ item.state }}"
   with_items: "{{ nrinfragent_integrations }}"
-  when: nrinfragent_os_name != 'windows' and ansible_version.full >= "2.8.0" and nrinfragent_os_name != 'amazon' and nrinfragent_os_name != 'redhat'
+  when: nrinfragent_os_name != 'windows' and ansible_version.full is version("2.8.0", '>=') and nrinfragent_os_name != 'amazon' and nrinfragent_os_name != 'redhat'
 
 - name: Install integrations yum
   yum:
@@ -140,7 +140,7 @@
     state: "{{ item.state }}"
     lock_timeout: "{{ nrinfragent_yum_lock_timeout }}"
   with_items: "{{ nrinfragent_integrations }}"
-  when: nrinfragent_os_name == 'redhat' or nrinfragent_os_name == 'amazon' and ansible_version.full >= "2.8.0"
+  when: nrinfragent_os_name == 'redhat' or nrinfragent_os_name == 'amazon' and ansible_version.full is version("2.8.0", '>=')
 
 - name: install agent (windows)
   win_chocolatey:


### PR DESCRIPTION
some context

```
$ ansible --version
ansible [core 2.13.3]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ec2-user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.9/site-packages/ansible
  ansible collection location = /home/ec2-user/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.9.10 (main, Feb  9 2022, 00:00:00) [GCC 11.2.1 20220127 (Red Hat 11.2.1-9)]
  jinja version = 3.1.2
  libyaml = True
```

Before change
```
$ ansible-playbook -i ./inventory.local myplaybook.yml
[WARNING]: Found both group and host with same name: localhost

PLAY [localhost] ******************************************************************************************************************************************************************

...

TASK [/home/ec2-user/ansible/infrastructure-agent-ansible : confirm redhat lsb util is present pre2.8.0] **************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failures": ["No package redhat-lsb-core available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```

After change

```
$ ansible-playbook -i ./inventory.local myplaybook.yml
[WARNING]: Found both group and host with same name: localhost

PLAY [localhost] ******************************************************************************************************************************************************************

...

TASK [/home/ec2-user/ansible/infrastructure-agent-ansible : confirm redhat lsb util is present pre2.8.0] **************************************************************************
skipping: [localhost]

TASK [/home/ec2-user/ansible/infrastructure-agent-ansible : confirm redhat lsb util is present post2.8.0] *************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failures": ["No package redhat-lsb-core available."], "msg": "Failed to install some of the specified packages", "rc": 1, "results": []}
```