### PR TITLE
feat: added nr_deployed_by custom_attribute for measurement of ansible usage

### DIFF
--- a/molecule/default/fixtures/newrelic-infra-expected.yml
+++ b/molecule/default/fixtures/newrelic-infra-expected.yml
@@ -1,4 +1,5 @@
 custom_attributes:
   business_unit: engineering
+  nr_deployed_by: ansible.infra
   team: newrelic
 license_key: Q000000000000000000000000000000000000000

--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -43,10 +43,18 @@
     - nrinfragent_os_name != 'windows'
     - nrinfragent_config_stat.stat.exists == false or nrinfragent_config_stat.stat.mode != '0600'
 
+- name: Add nr_deployed_by to custom attributes list
+  set_fact:
+    custom_attributes: "{{ nrinfragent_config['custom_attributes'] | default({}) | combine({'nr_deployed_by': 'ansible.infra'}, recursive=true) }}"
+
+- name: Combine new custom_attributes with existing values in nrinfragent_config
+  set_fact:
+    nrinfragent_config_adapted: "{{ nrinfragent_config | default({}) | combine({'custom_attributes': custom_attributes}, recursive=true) }}"
+
 - name: Setup agent config *NIX
   merge_yaml:
     src: "{{ nrinfragent_config_path }}"
-    value: "{{ nrinfragent_config }}"
+    value: "{{ nrinfragent_config_adapted }}"
   no_log: "{{ nrinfragent_hide_config_values }}"
   notify: restart newrelic-infra
   when:

--- a/templates/newrelic-infra.yml.j2
+++ b/templates/newrelic-infra.yml.j2
@@ -1,5 +1,5 @@
 {# Print out all the configuration options #}
-{{ nrinfragent_config | to_nice_yaml }}
+{{ nrinfragent_config_adapted | to_nice_yaml }}
 
 {# For backward compatibility, the license key will be written if it is defined #}
 {% if nrinfragent_license_key is defined %}


### PR DESCRIPTION
We want to track the usage of Ansible usage with New Relic to prove it's an invaluable tool for scaling and deploying New Relic. This will add the `nr_deployed_by` label + `ansible.infra` to all deployed hosts. 