### PR TITLE
Fix Amazon Linux 2023 support and improve version pinning idempotency

### DIFF
--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -20,7 +20,10 @@
 
 - name: confirm python-pip is present
   package:
-    name: "{{ (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023') | ternary('python3-pip', 'python-pip') }}"
+    name: >-
+      {{ ( (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023') or 
+           (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8) ) 
+         | ternary('python3-pip', 'python-pip') }}
     state: present
   when: 
     - nrinfragent_manage_repository | default(true)

--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -18,14 +18,28 @@
     - ansible_python_version is version('3.0', '>=')
     - ansible_facts['os_family'] == 'Debian'
 
+- name: confirm python-pip is present
+  package:
+    name: "{{ (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023') | ternary('python3-pip', 'python-pip') }}"
+    state: present
+  when: 
+    - nrinfragent_manage_repository | default(true)
+    - nrinfragent_state != "absent"
+    - ansible_facts['os_family'] == 'RedHat'
+  register: pip_install_result
+  ignore_errors: yes
+
 - name: ensure pyYAML is installed via pip
   pip:
     name: PyYAML
-  when:
+    state: present
+  when: 
     - nrinfragent_state != "absent"
-    - nrinfragent_os_name != "windows"
-    - ansible_python_version is version('3.0', '>=')
+    - nrinfragent_os_name != 'windows'
     - ansible_facts['os_family'] == 'RedHat'
+    - ansible_python_version is version('3.0', '>=')
+    - not pip_install_result.failed | default(false)
+  ignore_errors: yes
 
 - name: Stat newrelic-infra.yml config file
   stat:

--- a/tasks/configure_agent.yml
+++ b/tasks/configure_agent.yml
@@ -2,7 +2,7 @@
 - name: ensure python-yaml is installed
   package:
     name: python-yaml
-    state: "{{ nrinfragent_state }}"
+    state: "{{ (nrinfragent_state in ['absent', 'removed']) | ternary(nrinfragent_state, 'present') }}"
   when:
     - nrinfragent_state != "absent"
     - nrinfragent_os_name != 'windows'
@@ -11,7 +11,7 @@
 - name: ensure python3-yaml is installed
   package:
     name: python3-yaml
-    state: "{{ nrinfragent_state }}"
+    state: "{{ (nrinfragent_state in ['absent', 'removed']) | ternary(nrinfragent_state, 'present') }}"
   when:
     - nrinfragent_state != "absent"
     - nrinfragent_os_name != 'windows'

--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -3,14 +3,20 @@
   yum:
     name: redhat-lsb-core
     state: present
-  when: nrinfragent_os_name == 'redhat' and ansible_version.full is version("2.8.0", '<')
+  when: 
+    - nrinfragent_os_name == 'redhat'
+    - ansible_version.full is version("2.8.0", '<')
+    - not (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023')
 
 - name: confirm redhat lsb util is present post2.8.0
   yum:
     name: redhat-lsb-core
     state: present
     lock_timeout: "{{ nrinfragent_yum_lock_timeout }}"
-  when: nrinfragent_os_name == 'redhat' and ansible_version.full is version("2.8.0", '>=')
+  when: 
+    - nrinfragent_os_name == 'redhat'
+    - ansible_version.full is version("2.8.0", '>=')
+    - not (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023')
 
 - name: reread ansible_lsb facts
   setup:
@@ -51,14 +57,23 @@
 
 - name: setup agent repo reference
   yum_repository:
-    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ (ansible_service_mgr == 'upstart') | ternary('6', '7') }}/{{ ansible_architecture }}"
-    gpgcheck: "yes"
-    gpgkey: https://download.newrelic.com/infrastructure_agent/keys/newrelic_rpm_key_current.gpg
     name: 'newrelic-infra'
-    repo_gpgcheck: 'yes'
-    state: present
     description: New Relic Infrastructure
-  when: nrinfragent_distribution == 'amazon'
+    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ repo_version }}/{{ ansible_architecture }}"
+    gpgcheck: yes
+    repo_gpgcheck: "{{ (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023') | ternary('no', 'yes') }}"
+    gpgkey: https://download.newrelic.com/infrastructure_agent/keys/newrelic_rpm_key_current.gpg
+    state: present
+  vars:
+    repo_version: >-
+      {% if ansible_distribution == 'Amazon' and ansible_distribution_major_version == '2023' %}
+      8
+      {% elif ansible_service_mgr == 'upstart' %}
+      6
+      {% else %}
+      7
+      {% endif %}
+  when: ansible_distribution | lower == 'amazon' or nrinfragent_distribution == 'amazon'
   register: setup_agent_repo_amazon
 
 - name: setup agent repo reference
@@ -113,10 +128,15 @@
 
 - name: Install agent yum
   yum:
-    name: "newrelic-infra"
-    state: "{{ nrinfragent_state }}"
+    name: >-
+      {% if nrinfragent_state not in ['present', 'latest', 'absent', 'installed', 'removed'] %}
+      newrelic-infra-{{ nrinfragent_state }}
+      {% else %}
+      newrelic-infra
+      {% endif %}
+    state: "{{ (nrinfragent_state not in ['present', 'latest', 'absent', 'installed', 'removed']) | ternary('present', nrinfragent_state) }}"
+    allow_downgrade: yes 
     lock_timeout: "{{ nrinfragent_yum_lock_timeout }}"
-  when: (nrinfragent_os_name == 'redhat' or nrinfragent_os_name == 'amazon') and ansible_version.full is version("2.8.0", '>=')
 
 - name: install integrations pre2.8.0
   package:

--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -59,20 +59,13 @@
   yum_repository:
     name: 'newrelic-infra'
     description: New Relic Infrastructure
-    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ repo_version }}/{{ ansible_architecture }}"
+    baseurl: "https://download.newrelic.com/infrastructure_agent/linux/yum/el/{{ repo_version }}/$basearch"
     gpgcheck: yes
     repo_gpgcheck: "{{ (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023') | ternary('no', 'yes') }}"
     gpgkey: https://download.newrelic.com/infrastructure_agent/keys/newrelic_rpm_key_current.gpg
     state: present
   vars:
-    repo_version: >-
-      {% if ansible_distribution == 'Amazon' and ansible_distribution_major_version == '2023' %}
-      8
-      {% elif ansible_service_mgr == 'upstart' %}
-      6
-      {% else %}
-      7
-      {% endif %}
+    repo_version: "{{ (ansible_distribution == 'Amazon' and ansible_distribution_major_version | string == '2023') | ternary('8', (ansible_service_mgr == 'upstart') | ternary('6', '7')) }}"
   when: ansible_distribution | lower == 'amazon' or nrinfragent_distribution == 'amazon'
   register: setup_agent_repo_amazon
 

--- a/tasks/install_dist_pkgs.yml
+++ b/tasks/install_dist_pkgs.yml
@@ -130,6 +130,9 @@
     state: "{{ (nrinfragent_state not in ['present', 'latest', 'absent', 'installed', 'removed']) | ternary('present', nrinfragent_state) }}"
     allow_downgrade: yes 
     lock_timeout: "{{ nrinfragent_yum_lock_timeout }}"
+  when: 
+    - (nrinfragent_os_name == 'redhat' or nrinfragent_os_name == 'amazon' or ansible_os_family == 'RedHat')
+    - ansible_version.full is version("2.8.0", '>=')
 
 - name: install integrations pre2.8.0
   package:

--- a/templates/newrelic-logging.yml.j2
+++ b/templates/newrelic-logging.yml.j2
@@ -1,9 +1,4 @@
-{% if nrinfragent_logging is defined -%}
+{% if nrinfragent_logging is defined and nrinfragent_logging %}
 logs:
-{%- set log_config = nrinfragent_logging | to_nice_yaml(indent=2, sort_keys=False) %}
-{%- for entry in log_config.split("\n") %}
-{%- if entry != "" %}
-  {{ entry }}
-{%- endif -%}
-{%- endfor -%}
+{{ nrinfragent_logging | to_nice_yaml(indent=2) }}
 {% endif %}

--- a/templates/newrelic-logging.yml.j2
+++ b/templates/newrelic-logging.yml.j2
@@ -1,4 +1,4 @@
 {% if nrinfragent_logging is defined and nrinfragent_logging %}
 logs:
-{{ nrinfragent_logging | to_nice_yaml(indent=2) }}
+{{ nrinfragent_logging | to_nice_yaml(indent=2) | indent(2, first=True) }}
 {% endif %}


### PR DESCRIPTION
**Description**
This PR addresses several issues regarding Amazon Linux 2023 (AL2023) compatibility and fixes a bug where providing a version string to nrinfragent_state caused the yum/dnf modules to fail.

**Key Changes**

- **AL2023 Support:**
  - Skipped redhat-lsb-core installation on AL2023 (package unavailable).
  - Updated repository logic to correctly route AL2023 to the EL8 repository.
  - Set repo_gpgcheck: no specifically for AL2023 to bypass metadata signature requirements not supported by the current NR repo.

- **Version Pinning & Idempotency:**
  - Refactored Install agent yum to allow nrinfragent_state to accept version strings (e.g., 1.71.4-1.el8) by moving the version to the package name and forcing state: present.
  - Isolated python-yaml dependency states from the global agent version string to prevent "invalid state" errors on legacy systems.

- **Dependency Management:**
  - Updated python-pip package naming logic to support the python3-pip requirement on RHEL 8+ and AL2023.
  - Gated PyYAML installation via Pip to be non-blocking if Pip is unavailable.

**Verification Results**
Validated the following on clean AMI instances:
- **Amazon Linux 2023**: Successful install, version pinning to 1.71.4-1.el8, and verified log forwarding (fluent-bit) activity.
- **RHEL 8**: Successful install and verified python3-pip dependency resolution, and verified log forwarding (fluent-bit) activity.
- **Amazon Linux 2**: Confirmed no regressions; correctly routed to EL7 repo and handled python-yaml dependency.